### PR TITLE
Allow negative `n` and `prop` in all slice variants

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -35,8 +35,8 @@
 #'   proportion of rows to select. If neither are supplied, `n = 1` will be
 #'   used.
 #'
-#"   A positive value of `n` includes the first/last `n` rows, while a negative 
-#'   value excludes the last/first `abs(n)` rows.
+#'   If a negative value of `n` or `prop` is provided, the specified number or
+#'   proportion of rows will be removed.
 #'
 #'   If `n` is greater than the number of rows in the group (or `prop > 1`),
 #'   the result will be silently truncated to the group size. If the
@@ -133,15 +133,8 @@ slice_head <- function(.data, ..., n, prop) {
 #' @export
 slice_head.data.frame <- function(.data, ..., n, prop) {
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop, "slice_head")
-  idx <- switch(size$type,
-    n = function(n) {
-      idx_end = if (size$n < 0) max(n + size$n, 0) else min(size$n, n)
-      seq2(1, idx_end)
-    },
-    prop = function(n) seq2(1, min(size$prop * n, n))
-  )
-
+  size <- compute_slice_size(n, prop, "slice_head")
+  idx <- function(n) seq2(1, min(max(size(n), 0), n))
   slice(.data, idx(dplyr::n()))
 }
 
@@ -154,14 +147,8 @@ slice_tail <- function(.data, ..., n, prop) {
 #' @export
 slice_tail.data.frame <- function(.data, ..., n, prop) {
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop, "slice_tail")
-  idx <- switch(size$type,
-    n = function(n) {
-      idx_start <- if (size$n < 0) max(1 - size$n, 0) else max(n - size$n + 1, 1)
-      seq2(idx_start, n)
-    },
-    prop = function(n) seq2(max(ceiling(n - size$prop * n) + 1, 1), n)
-  )
+  size <- compute_slice_size(n, prop, "slice_tail")
+  idx <- function(n) seq2(max(n - size(n) + 1, 1), n)
   slice(.data, idx(dplyr::n()))
 }
 
@@ -182,17 +169,11 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   }
 
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop, "slice_min")
+  size <- compute_slice_size(n, prop, "slice_min")
   if (with_ties) {
-    idx <- switch(size$type,
-      n =    function(x, n) head(order(x), smaller_ranks(x, size$n)),
-      prop = function(x, n) head(order(x), smaller_ranks(x, size$prop * n))
-    )
+    idx <- function(x, n) head(order(x), smaller_ranks(x, size(n)))
   } else {
-    idx <- switch(size$type,
-      n =    function(x, n) head(order(x), size$n),
-      prop = function(x, n) head(order(x), size$prop * n)
-    )
+    idx <- function(x, n) head(order(x), size(n))
   }
   slice(.data, idx({{ order_by }}, dplyr::n()))
 }
@@ -209,21 +190,13 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     abort("argument `order_by` is missing, with no default.")
   }
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop, "slice_max")
+  size <- compute_slice_size(n, prop, "slice_max")
   if (with_ties) {
-    idx <- switch(size$type,
-      n =    function(x, n) head(
-        order(x, decreasing = TRUE), smaller_ranks(desc(x), size$n)
-      ),
-      prop = function(x, n) head(
-        order(x, decreasing = TRUE), smaller_ranks(desc(x), size$prop * n)
-      )
+    idx <- function(x, n) head(
+        order(x, decreasing = TRUE), smaller_ranks(desc(x), size(n))
     )
   } else {
-    idx <- switch(size$type,
-      n =    function(x, n) head(order(x, decreasing = TRUE), size$n),
-      prop = function(x, n) head(order(x, decreasing = TRUE), size$prop * n)
-    )
+    idx <- function(x, n) head(order(x, decreasing = TRUE), size(n))
   }
 
   slice(.data, idx({{ order_by }}, dplyr::n()))
@@ -242,12 +215,9 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
-  size <- check_slice_size(n, prop, "slice_sample")
   ellipsis::check_dots_empty()
-  idx <- switch(size$type,
-    n =    function(x, n) sample_int(n, size$n, replace = replace, wt = x),
-    prop = function(x, n) sample_int(n, size$prop * n, replace = replace, wt = x),
-  )
+  size <- compute_slice_size(n, prop, "slice_sample")
+  idx <- function(x, n) sample_int(n, size(n), replace = replace, wt = x)
   slice(.data, idx({{ weight_by }}, dplyr::n()))
 }
 
@@ -313,24 +283,35 @@ check_slice_size <- function(n, prop, .slice_fn = "check_slice_size") {
   } else if (!missing(n) && missing(prop)) {
     n <- check_constant(n, "n", .slice_fn)
     if (!is.numeric(n) || length(n) != 1 || is.na(n)) {
-      abort("`n` must be a single non-missing number.")
+      abort("`n` must be a single number.")
     }
-    if (n < 0 && !.slice_fn %in% c("slice_head", "slice_tail")) {
-      abort(glue("`n` must be a positive number in `{.slice_fn}()`."))
-    }
-
     list(type = "n", n = n)
   } else if (!missing(prop) && missing(n)) {
     prop <- check_constant(prop, "prop", .slice_fn)
     if (!is.numeric(prop) || length(prop) != 1 || is.na(prop)) {
-      abort("`prop` must be a single non-missing number.")
-    }
-    if (prop < 0) {
-      abort("`prop` must be a positive number.")
+      abort("`prop` must be a single number.")
     }
     list(type = "prop", prop = prop)
   } else {
     abort("Must supply exactly one of `n` and `prop` arguments.")
+  }
+}
+
+compute_slice_size <- function(n, prop, .slice_fn = "compute_slice_size") {
+  slice_input <- check_slice_size(n, prop, .slice_fn)
+
+  if (slice_input$type == "n") {
+    if (slice_input$n < 0) {
+      function(n) n + slice_input$n
+    } else {
+      function(n) slice_input$n
+    }
+  } else if (slice_input$type == "prop") {
+    if (slice_input$prop < 0) {
+      function(n) ceiling(n + slice_input$prop * n)
+    } else {
+      function(n) floor(slice_input$prop * n)
+    }
   }
 }
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -38,28 +38,14 @@
     Code
       check_slice_size(n = "a")
     Error <rlang_error>
-      `n` must be a single non-missing number.
+      `n` must be a single number.
 
 ---
 
     Code
       check_slice_size(prop = "a")
     Error <rlang_error>
-      `prop` must be a single non-missing number.
-
----
-
-    Code
-      check_slice_size(n = -1)
-    Error <rlang_error>
-      `n` must be a positive number in `check_slice_size()`.
-
----
-
-    Code
-      check_slice_size(prop = -1)
-    Error <rlang_error>
-      `prop` must be a positive number.
+      `prop` must be a single number.
 
 ---
 
@@ -82,12 +68,12 @@
     Code
       check_slice_size(n = NA)
     Error <rlang_error>
-      `n` must be a single non-missing number.
+      `n` must be a single number.
 
 ---
 
     Code
       check_slice_size(prop = NA)
     Error <rlang_error>
-      `prop` must be a single non-missing number.
+      `prop` must be a single number.
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -332,8 +332,6 @@ test_that("rename errors with invalid grouped data frame (#640)", {
   expect_snapshot(error = TRUE, check_slice_size(n = 1, prop = 1))
   expect_snapshot(error = TRUE, check_slice_size(n = "a"))
   expect_snapshot(error = TRUE, check_slice_size(prop = "a"))
-  expect_snapshot(error = TRUE, check_slice_size(n = -1))
-  expect_snapshot(error = TRUE, check_slice_size(prop = -1))
   expect_snapshot(error = TRUE, check_slice_size(n = n()))
   expect_snapshot(error = TRUE, check_slice_size(prop = n()))
   expect_snapshot(error = TRUE, check_slice_size(n = NA))

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -315,6 +315,14 @@ test_that("slice_head/slice_tail correctly slice grouped df when n < 0", {
 
 })
 
+test_that("Non-integer number of rows computed correctly", {
+  expect_equal(get_slice_size(n = 1.6)(10), 1)
+  expect_equal(get_slice_size(prop = 0.16)(10), 1)
+  expect_equal(get_slice_size(n = -1.6)(10), 9)
+  expect_equal(get_slice_size(prop = -0.16)(10), 9)
+})
+
+
 # Errors ------------------------------------------------------------------
 
 test_that("rename errors with invalid grouped data frame (#640)", {


### PR DESCRIPTION
The calculation of slice size depending on sign and argument provided
is now done in a separate function `compute_slice_size`, eliminating the
need for `switch` and `if` statements in all slice variants